### PR TITLE
Add `into_inner` methods for `Implicit`, `Explicit` and `Enumerated`

### DIFF
--- a/asn1-core/src/types/enumerated.rs
+++ b/asn1-core/src/types/enumerated.rs
@@ -1,10 +1,4 @@
-use serde::{
-    Deserialize,
-    Deserializer,
-    Serialize,
-    Serializer,
-};
-
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// A representation of the `ENUMERATED` ASN.1 data type. `Enumerated` should be
 /// a wrapper around an `enum` with no inner data. Using `Enumerated` will
@@ -17,6 +11,11 @@ impl<E: Enumerable> Enumerated<E> {
     /// Instantiate a new instance of `Enumerated` with an `Enumerable` variant.
     pub fn new(enumerable: E) -> Self {
         Enumerated(enumerable)
+    }
+
+    /// Consumes self and returns the inner `Enumerable` variant from an instance of `Enumerated`.
+    pub fn into_inner(self) -> E {
+        self.0
     }
 }
 
@@ -42,4 +41,3 @@ impl<'de, E: Enumerable + Deserialize<'de>> Deserialize<'de> for Enumerated<E> {
         Ok(Enumerated(E::deserialize(deserializer)?))
     }
 }
-

--- a/asn1-core/src/types/prefix.rs
+++ b/asn1-core/src/types/prefix.rs
@@ -1,28 +1,23 @@
 use std::marker::PhantomData;
 
-use serde::{
-    Deserialize,
-    Deserializer,
-    Serialize,
-    Serializer,
-};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typenum::marker_traits::Unsigned;
 
-use crate::identifier::Identifier;
 use crate::identifier::constant::*;
+use crate::identifier::Identifier;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename = "ASN.1#Explicit")]
 pub struct Explicit<C: Class, N: Unsigned, T> {
     #[serde(skip)]
     phantom: std::marker::PhantomData<ConstIdentifier<C, N>>,
-    value: T
+    value: T,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Implicit<C: Class, N: Unsigned, T> {
     phantom: std::marker::PhantomData<ConstIdentifier<C, N>>,
-    value: T
+    value: T,
 }
 
 impl<C: Class, N: Unsigned, T> Implicit<C, N, T> {
@@ -32,6 +27,10 @@ impl<C: Class, N: Unsigned, T> Implicit<C, N, T> {
             phantom: PhantomData,
         }
     }
+
+    pub fn into_inner(self) -> T {
+        self.value
+    }
 }
 
 impl<C: Class, N: Unsigned, T> Explicit<C, N, T> {
@@ -40,6 +39,10 @@ impl<C: Class, N: Unsigned, T> Explicit<C, N, T> {
             value,
             phantom: PhantomData,
         }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.value
     }
 }
 
@@ -62,11 +65,10 @@ impl<C: Class, N: Unsigned, T: Serialize> Serialize for Implicit<C, N, T> {
         S: Serializer,
     {
         let identifier = Self::IDENTIFIER;
-        serializer.serialize_newtype_struct("ASN.1#Implicit", &(
-                identifier.class as u8,
-                identifier.tag,
-                &self.value
-        ))
+        serializer.serialize_newtype_struct(
+            "ASN.1#Implicit",
+            &(identifier.class as u8, identifier.tag, &self.value),
+        )
     }
 }
 
@@ -85,10 +87,9 @@ impl<C: Class, N: Unsigned, T: Serialize> Serialize for Explicit<C, N, T> {
         S: Serializer,
     {
         let identifier = Self::IDENTIFIER;
-        serializer.serialize_newtype_struct("ASN.1#Explicit", &(
-                identifier.class as u8,
-                identifier.tag,
-                &self.value
-        ))
+        serializer.serialize_newtype_struct(
+            "ASN.1#Explicit",
+            &(identifier.class as u8, identifier.tag, &self.value),
+        )
     }
 }


### PR DESCRIPTION
Adds methods for retrieving the inner values to several structs.